### PR TITLE
Explicitly specify ABI when building firmware/software

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -4,7 +4,7 @@ SOURCES = boot.S
 
 COMMON_DIR = $(dir $(lastword $(MAKEFILE_LIST)))
 
-CFLAGS = -Wall -flto -march=rv32i -ffreestanding -nostdlib
+CFLAGS = -Wall -flto -march=rv32i -mabi=ilp32 -ffreestanding -nostdlib
 DFLAGS = --line-numbers
  
 ELF = boot.elf

--- a/software/common/common.mk
+++ b/software/common/common.mk
@@ -7,7 +7,7 @@ ifeq ($(OPT_LEVEL),)
 OPT_LEVEL := -Os
 endif
 
-CFLAGS = -Wall $(OPT_LEVEL) -flto -march=rv32i -I$(COMMON_DIR) -I$(COMMON_DIR)../lib/ -I./ -ffreestanding -nostdlib
+CFLAGS = -Wall $(OPT_LEVEL) -flto -march=rv32i -mabi=ilp32 -I$(COMMON_DIR) -I$(COMMON_DIR)../lib/ -I./ -ffreestanding -nostdlib
 DFLAGS = --line-numbers
  
 LDS = ../common/sections.lds


### PR DESCRIPTION
This allows using the prebuilt `riscv64-unknown-elf` cross-compiler in Debian.

I think this shouldn't break anything with your preferred toolchain; feel free to close the PR if it does.