### PR TITLE
Add library for status leds

### DIFF
--- a/software/blinky/.gitignore
+++ b/software/blinky/.gitignore
@@ -1,0 +1,12 @@
+# GCC
+
+*.elf
+*.bin
+*.hex
+
+/sections_p.lds
+
+# Optional disassembly
+
+/dasm
+

--- a/software/blinky/Makefile
+++ b/software/blinky/Makefile
@@ -1,0 +1,7 @@
+SOURCES = \
+	main.c \
+	../lib/status.c \
+	../lib/vdp.c \
+
+include ../common/core.mk
+

--- a/software/blinky/main.c
+++ b/software/blinky/main.c
@@ -1,0 +1,21 @@
+// main.c
+//
+// Copyright (C) 2020 Dan Rodrigues <danrr.gh.oss@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "vdp.h"
+#include "status.h"
+
+int main() {
+    // Blink leds 0..7 along to the vsync clock
+    uint32_t frame = 0;
+    while (true) {
+        status_set_leds(frame / 16);
+        vdp_wait_frame_ended();
+        frame += 1;
+    }
+}

--- a/software/lib/status.c
+++ b/software/lib/status.c
@@ -1,0 +1,11 @@
+// status.c
+//
+// Copyright (C) 2020 Dan Rodrigues <danrr.gh.oss@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "status.h"
+
+void status_set_leds(uint8_t val) {
+    SYS_STATUS_LEDS = val;
+}

--- a/software/lib/status.h
+++ b/software/lib/status.h
@@ -1,0 +1,21 @@
+// status.h
+//
+// Copyright (C) 2020 Dan Rodrigues <danrr.gh.oss@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef status_h
+#define status_h
+
+#include <stdint.h>
+#include <stdbool.h>
+
+static volatile void *const SYS_STATUS_BASE = (uint32_t *)0x20000;
+typedef volatile uint32_t *const SYS_STATUS_REG;
+
+#define SYS_STATUS_LEDS (*((SYS_STATUS_REG)SYS_STATUS_BASE + 0))
+
+// Sets the status leds on the board. Takes a bitmask.
+void status_set_leds(uint8_t val);
+
+#endif


### PR DESCRIPTION
I don't know if this is useful, but while looking at the address decoder I noticed there were libraries for every one of the peripherals but this one :smile: 

Add a library for the system status. Currently this has only one functionality: set the 8 leds on the ULX3S:

    void status_set_leds(uint8_t val);

Also add a simple application "blinky" that demonstrates this.