### PR TITLE
Connect DOWN button on ULX3S PCB

### DIFF
--- a/hardware/ulx3s/ics32_top_ulx3s.v
+++ b/hardware/ulx3s/ics32_top_ulx3s.v
@@ -255,7 +255,7 @@ module ics32_top_ulx3s #(
 
     // --- Gamepad reading ---
 
-    wire [11:0] pcb_btn = {btn[6], btn[5], 1'b0, btn[3], 1'b0, !btn[0], btn[1], btn[2]};
+    wire [11:0] pcb_btn = {btn[6], btn[5], btn[4], btn[3], 1'b0, !btn[0], btn[1], btn[2]};
     wire [11:0] pad_btn = ENABLE_USB_GAMEPAD ? usb_btn_cdc : pcb_btn;
 
     wire [1:0] pad_read_data;


### PR DESCRIPTION
I'm not sure why the button was not connected, but as I don't have my USB gamepad working yet I noticed it was missing.