### PR TITLE
software: Add Wextra flag for compiler

### DIFF
--- a/software/common/core.mk
+++ b/software/common/core.mk
@@ -53,7 +53,7 @@ endif
 
 CFLAGS := \
 	-std=c11 \
-	-Wall $(OPT_LEVEL) -MMD -MP -flto -march=rv32i -mabi=ilp32 \
+	-Wall -Wextra $(OPT_LEVEL) -MMD -MP -flto -march=rv32i -mabi=ilp32 \
 	-I$(MK_DIR)../common/ -I$(MK_DIR)../lib/ -I./ \
 	-ffreestanding -nostdlib
 


### PR DESCRIPTION
This makes gcc warn about uninitialized and unused variables, among other things.