### PR TITLE
software: Expose upload_font_remapped_main for custom fonts

### DIFF
--- a/software/common/font.c
+++ b/software/common/font.c
@@ -14,23 +14,19 @@
 
 // this converts the 1bpp font tiles to the required 4bpp color format
 
-static void upload_font_remapped_main(uint16_t vram_base, uint8_t transparent, uint8_t opaque, const char font[][8]);
-
 void upload_font(uint16_t vram_base) {
     upload_font_remapped(vram_base, 0, 1);
 }
 
 void upload_font_minimal(uint16_t vram_base) {
-    upload_font_remapped_main(vram_base, 0, 1, font8x8_minimal);
+    upload_font_remapped_main(vram_base, 0, 1, font8x8_minimal, sizeof(font8x8_minimal)/8);
 }
 
 void upload_font_remapped(uint16_t vram_base, uint8_t transparent, uint8_t opaque) {
-    upload_font_remapped_main(vram_base, transparent, opaque, font8x8_basic);
+    upload_font_remapped_main(vram_base, transparent, opaque, font8x8_basic, sizeof(font8x8_basic)/8);
 }
 
-void upload_font_remapped_main(uint16_t vram_base, uint8_t transparent, uint8_t opaque, const char font[][8]) {
-    const uint16_t char_total = 128;
-
+void upload_font_remapped_main(uint16_t vram_base, uint8_t transparent, uint8_t opaque, const char font[][8], uint16_t char_total) {
     vdp_seek_vram(vram_base);
     vdp_set_vram_increment(1);
 

--- a/software/common/font.h
+++ b/software/common/font.h
@@ -1,4 +1,4 @@
-// font.h
+// font.h: Convert 8x8 1bpp font tiles to the required 4bpp color format.
 //
 // Copyright (C) 2020 Dan Rodrigues <danrr.gh.oss@gmail.com>
 //
@@ -7,8 +7,18 @@
 #ifndef font_h
 #define font_h
 
+// Upload a 128-character ASCII font at vram_base.
 void upload_font(uint16_t vram_base);
+
+// Upload a minimal uppercase latin only font at vram_base.
 void upload_font_minimal(uint16_t vram_base);
+
+// Upload a default 128-character ASCII font at vram_base, providing a color
+// 0..15 to use for foreground and background.
 void upload_font_remapped(uint16_t vram_base, uint8_t transparent, uint8_t opaque);
+
+// Upload a specified font with specified number of characters at vram_base,
+// providing a color 0..15 to use for foreground and background.
+void upload_font_remapped_main(uint16_t vram_base, uint8_t transparent, uint8_t opaque, const char font[][8], uint16_t char_total);
 
 #endif /* font_h */


### PR DESCRIPTION
Expose the function `upload_font_remapped_main` and add a parameter specifying the number of characters, to facilitate uploading a non-default font.

Also add documentation for `font.h` functions.