### PR TITLE
software: Allow demos to override ASM

### DIFF
--- a/software/common/core.mk
+++ b/software/common/core.mk
@@ -42,7 +42,7 @@ $(call build_util,$(HEADER_GEN_NEEDED),$(HEADER_GEN_DIR),header_gen)
 
 ###
 
-ASM := $(addprefix $(MK_DIR), \
+ASM += $(addprefix $(MK_DIR), \
 	vectors.S \
 	start.S \
 	)


### PR DESCRIPTION
Change core.mk to make it possible for demos to define their own assembler source files, this allows for say, a demo to be implemented purely in assembler.