### PR TITLE
Add comments regarding ADPCM block sizes

### DIFF
--- a/hardware/ics_adpcm.v
+++ b/hardware/ics_adpcm.v
@@ -8,7 +8,7 @@
 
 module ics_adpcm #(
     parameter integer OUTPUT_INTERVAL = 33700000 / 44100,
-    parameter [15:0] ADPCM_BLOCK_SIZE = 1024 * 2,
+    parameter [15:0] ADPCM_BLOCK_SIZE = 1024 * 2, // in nibbles
     parameter [3:0] CHANNELS = 8,
     parameter ADPCM_STEP_LUT_PATH = "adpcm_step_lut.hex",
 

--- a/software/lib/audio.c
+++ b/software/lib/audio.c
@@ -17,7 +17,7 @@ void audio_set_aligned_addresses(volatile AudioChannel *channel, const int16_t *
 
 void audio_aligned_addresses(const int16_t *start, size_t length, AudioAlignedAddresses *addresses) {
     const uintptr_t cpu_flash_base = 0x1000000;
-    const size_t adpcm_block_size = 0x400;
+    const size_t adpcm_block_size = 0x400; // in bytes
 
     uintptr_t block_start = (((size_t)start - cpu_flash_base)) / adpcm_block_size;
     uintptr_t block_end = block_start + (length + (adpcm_block_size / 2 - 1)) / (adpcm_block_size / 2);

--- a/software/lib/audio.h
+++ b/software/lib/audio.h
@@ -64,8 +64,17 @@ typedef struct {
     uint16_t loop;
 } AudioAlignedAddresses;
 
+/**
+ * Set sample start address and length for a channel. The specified length is in
+ * 16-bit units. The loop address will be the same as the end address, so if
+ * looping is enabled the entire sample will loop.
+ */
 void audio_set_aligned_addresses(volatile AudioChannel *channel, const int16_t *start, size_t length);
 
+/**
+ * Compute sample start address and length for a channel. The specified length
+ * is in 16-bit units.
+ */
 void audio_aligned_addresses(const int16_t *start, size_t length, AudioAlignedAddresses *addresses);
 
 #endif /* audio_h */


### PR DESCRIPTION
It took a while for me to figure out how the various values for the ADPCM block size and sample sizes related to each other. Add a few comments in places to clarify.