### PR TITLE
Update for new version of yosys toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The system doesn't require any RAM beyond what is available in the iCE40 UP5K.
 
 The `CROSS` variable in `software/common/cross.mk` must be set according to the name of your RISC-V installation.
 
-While the RISC-V toolchain can be built from source, the PicoRV32 repo [includes a Makefile](https://github.com/cliffordwolf/picorv32#building-a-pure-rv32i-toolchain) with convenient build-and-install targets. This project only uses the `RV32I` ISA. Those with case-insensitive file systems will likely have issues building the toolchain from source. If so, binaries of the toolchain for various platforms are available [here](https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/tag/v8.3.0-1.1).
+While the RISC-V toolchain can be built from source, the PicoRV32 repo [includes a Makefile](https://github.com/cliffordwolf/picorv32#building-a-pure-rv32i-toolchain) with convenient build-and-install targets. This project only uses the `RV32I` ISA. Those with case-insensitive file systems will likely have issues building the toolchain from source. If so, binaries of the toolchain for various platforms are available [here](https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/tag/v13.2.0-2/).
 
 The open-tool-forge [fpga-toolchain](https://github.com/open-tool-forge/fpga-toolchain) project also provides nightly builds of most of these tools.
 

--- a/hardware/cop_ram.v
+++ b/hardware/cop_ram.v
@@ -33,10 +33,12 @@ module cop_ram(
 
     wire has_contention =  read_en && write_en && read_address == write_address;
 
+`ifndef SYNTHESIS
     always @(posedge clk) begin
         if (has_contention) begin
             $display("COP RAM contention: %x", read_address);
         end
     end
+`endif
 
 endmodule

--- a/hardware/ulx3s/ics32_top_ulx3s.v
+++ b/hardware/ulx3s/ics32_top_ulx3s.v
@@ -157,40 +157,76 @@ module ics32_top_ulx3s #(
     wire [3:0] flash_in_en_r;
     wire [3:0] flash_in_r;
 
-    (* BEL="X11/Y93/SLICEA" *) TRELLIS_SLICE flash_in_r_0 (
+    (* BEL="X11/Y93/SLICEA.FF0" *) TRELLIS_FF flash_in_r_0 (
         .CLK(clk_2x),
-        .M0(flash_in[0]), .M1(flash_in[1]),
-        .Q0(flash_in_r[0]), .Q1(flash_in_r[1])
+        .DI(flash_in[0]),
+        .Q(flash_in_r[0]),
     );
 
-    (* BEL="X11/Y93/SLICEB" *) TRELLIS_SLICE flash_in_r_1 (
+    (* BEL="X11/Y93/SLICEA.FF1" *) TRELLIS_FF flash_in_r_1 (
         .CLK(clk_2x),
-        .M0(flash_in[2]), .M1(flash_in[3]),
-        .Q0(flash_in_r[2]), .Q1(flash_in_r[3])
+        .DI(flash_in[1]),
+        .Q(flash_in_r[1]),
     );
 
-    (* BEL="X11/Y93/SLICEC" *) TRELLIS_SLICE flash_in_en_r_0 (
+    (* BEL="X11/Y93/SLICEB.FF0" *) TRELLIS_FF flash_in_r_2 (
         .CLK(clk_2x),
-        .M0(~flash_in_en[0]), .M1(~flash_in_en[1]),
-        .Q0(flash_in_en_r[0]), .Q1(flash_in_en_r[1])
+        .DI(flash_in[2]),
+        .Q(flash_in_r[2]),
     );
 
-    (* BEL="X11/Y93/SLICED" *) TRELLIS_SLICE flash_in_en_r_1 (
+    (* BEL="X11/Y93/SLICEB.FF1" *) TRELLIS_FF flash_in_r_3 (
         .CLK(clk_2x),
-        .M0(~flash_in_en[2]), .M1(~flash_in_en[3]),
-        .Q0(flash_in_en_r[2]), .Q1(flash_in_en_r[3])
+        .DI(flash_in[3]),
+        .Q(flash_in_r[3]),
     );
 
-    (* BEL="X9/Y93/SLICEA" *) TRELLIS_SLICE flash_out_r_0 (
+    (* BEL="X11/Y93/SLICEC.FF0" *) TRELLIS_FF flash_in_en_r_0 (
         .CLK(clk_2x),
-        .M0(flash_out[0]), .M1(flash_out[1]),
-        .Q0(flash_out_r[0]), .Q1(flash_out_r[1]),
+        .DI(~flash_in_en[0]),
+        .Q(flash_in_en_r[0]),
     );
 
-    (* BEL="X9/Y93/SLICEB" *) TRELLIS_SLICE flash_out_r_1 (
+    (* BEL="X11/Y93/SLICEC.FF1" *) TRELLIS_FF flash_in_en_r_1 (
         .CLK(clk_2x),
-        .M0(flash_out[2]), .M1(flash_out[3]),
-        .Q0(flash_out_r[2]), .Q1(flash_out_r[3]),
+        .DI(~flash_in_en[1]),
+        .Q(flash_in_en_r[1]),
+    );
+
+    (* BEL="X11/Y93/SLICED.FF0" *) TRELLIS_FF flash_in_en_r_2 (
+        .CLK(clk_2x),
+        .DI(~flash_in_en[2]),
+        .Q(flash_in_en_r[2]),
+    );
+
+    (* BEL="X11/Y93/SLICED.FF1" *) TRELLIS_FF flash_in_en_r_3 (
+        .CLK(clk_2x),
+        .DI(~flash_in_en[3]),
+        .Q(flash_in_en_r[3]),
+    );
+
+    (* BEL="X9/Y93/SLICEA.FF0" *) TRELLIS_FF flash_out_r_0 (
+        .CLK(clk_2x),
+        .DI(flash_out[0]),
+        .Q(flash_out_r[0]),
+    );
+
+    (* BEL="X9/Y93/SLICEA.FF1" *) TRELLIS_FF flash_out_r_1 (
+        .CLK(clk_2x),
+        .DI(flash_out[1]),
+        .Q(flash_out_r[1]),
+    );
+
+    (* BEL="X9/Y93/SLICEB.FF0" *) TRELLIS_FF flash_out_r_2 (
+        .CLK(clk_2x),
+        .DI(flash_out[2]),
+        .Q(flash_out_r[2]),
+    );
+
+    (* BEL="X9/Y93/SLICEB.FF1" *) TRELLIS_FF flash_out_r_3 (
+        .CLK(clk_2x),
+        .DI(flash_out[3]),
+        .Q(flash_out_r[3]),
     );
 
     BB flash_io_bb[3:0] (
@@ -204,10 +240,10 @@ module ics32_top_ulx3s #(
 
     wire flash_csn_r;
 
-    (* BEL="X15/Y93/SLICEA" *) TRELLIS_SLICE flash_csn_r_0 (
+    (* BEL="X15/Y93/SLICEA.FF0" *) TRELLIS_FF flash_csn_r_0 (
         .CLK(clk_2x),
-        .M0(flash_csn_io),
-        .Q0(flash_csn_r)
+        .DI(flash_csn_io),
+        .Q(flash_csn_r)
     );
 
     OB flash_csn_ob(
@@ -224,16 +260,16 @@ module ics32_top_ulx3s #(
     wire [1:0] flash_clk_ddr_r;
     wire flash_clk_out = clk_2x ? flash_clk_ddr_r[0] : flash_clk_ddr_r[1];
 
-    (* BEL="X2/Y93/SLICEA" *) TRELLIS_SLICE ddr_ff_0 (
+    (* BEL="X2/Y93/SLICEA.FF0" *) TRELLIS_FF ddr_ff_0 (
         .CLK(clk_2x),
-        .M0(flash_clk_ddr[0]),
-        .Q0(flash_clk_ddr_r[0])
+        .DI(flash_clk_ddr[0]),
+        .Q(flash_clk_ddr_r[0])
     );
 
-    (* BEL="X2/Y92/SLICEA" *) TRELLIS_SLICE #(.CLKMUX("INV")) ddr_ff_1 (
+    (* BEL="X2/Y92/SLICEA.FF0" *) TRELLIS_FF #(.CLKMUX("INV")) ddr_ff_1 (
         .CLK(clk_2x),
-        .M0(flash_clk_ddr[1]),
-        .Q0(flash_clk_ddr_r[1])
+        .DI(flash_clk_ddr[1]),
+        .Q(flash_clk_ddr_r[1])
     );
     
     USRMCLK spi_clk (

--- a/scripts/ecp5_brams.py
+++ b/scripts/ecp5_brams.py
@@ -166,7 +166,7 @@ def ram_interleave_test():
 
 def bootrom_test(config, design, firmware='../../firmware/boot_multi.bin'):
     # check that contents of the specified bram match the bootrom as expected
-    wid = design.wid_by_name['ics32.bootloader.0.0.0']
+    wid = design.wid_by_name['ics32.bootloader.0.0']
     bootrom = config.parse_bram_data(wid)
     data_check = open(firmware, 'rb').read()
     import struct
@@ -203,8 +203,8 @@ if __name__ == '__main__':
     # cpu_ram_1 has bits [31:16]
     # two RAMs (upper, lower 16 bit) each consisting of 16 BELs
     # seems the individual RAMs are sliced per bit 0..15, each item contains 8 bits (8 consecutive addresses)
-    cpu_ram = [design.wid_by_name['ics32.cpu_ram.cpu_ram_%d.mem.%d.0.0' % (bit // 16, bit % 16)] for bit in range(32)]
-    bootrom_wid = design.wid_by_name['ics32.bootloader.0.0.0']
+    cpu_ram = [design.wid_by_name['ics32.cpu_ram.cpu_ram_%d.mem.0.%d' % (bit // 16, bit % 16)] for bit in range(32)]
+    bootrom_wid = design.wid_by_name['ics32.bootloader.0.0']
 
     if perform_checks: # check for an initial RAM test pattern provided in verilog
         ram_data = [config.parse_bram_data(cpu_ram[bit]) for bit in range(32)]

--- a/software/common/cross.mk
+++ b/software/common/cross.mk
@@ -1,2 +1,2 @@
-CROSS ?= riscv-none-embed-
+CROSS ?= riscv-none-elf-
 


### PR DESCRIPTION
I've dusted off some of my old FPGA projects and ran into some issues compiling `icestation-32` with the new yosys toolchain. This makes the build work again with yesterday's daily build of `oss-cad-suite` and `xpack-riscv-none-elf-gcc`.

The only non-trivial part is the `TRELLIS_SLICE` split. It's no longer possible to define a slice as one element, but individual FFs need to be instantiated and placed. I hope I got everything correct. it appears to work.